### PR TITLE
Grab user's login shell instead of fish

### DIFF
--- a/.scripts/sysif.sh
+++ b/.scripts/sysif.sh
@@ -39,7 +39,7 @@ print-uptime()
 }
 
 print-shell() {
-  color-echo 'SH' '/usr/bin/fish'
+  color-echo 'SH' `ps -p $$ -o cmd | tail -1`
 }
 
 print-cpu()


### PR DESCRIPTION
The purpose of this change is to add functionality to the script in order to grab the user's login shell.

This won't allow functionality of getting the shell that is currently being used but is better than hard-coding a shell.
